### PR TITLE
fix: revert comment which disabled initialization

### DIFF
--- a/protocols/lbm_lib/smtc_modem_core/smtc_modem.c
+++ b/protocols/lbm_lib/smtc_modem_core/smtc_modem.c
@@ -188,8 +188,6 @@ typedef struct modem_key_ctx_s
  */
 
 radio_planner_t *  modem_radio_planner = NULL;
-ralf_t * modem_radio;
-/*
 #if defined( SX128X )
 ralf_t modem_radio = RALF_SX128X_INSTANTIATE( NULL );
 #elif defined( SX126X )
@@ -205,7 +203,6 @@ ralf_t          modem_radio = RALF_SX127X_INSTANTIATE( &sx127x );
 #else
 #error "Please select radio board.."
 #endif
-*/
 struct
 {
     uint8_t  modem_appkey_status;
@@ -291,19 +288,19 @@ void smtc_modem_set_radio_context( const void* radio_ctx )
 {
 #if defined( SX1272 ) || defined( SX1276 )
     // update modem_radio context with provided one
-    ( ( sx127x_t* ) modem_radio->ral.context )->hal_context = radio_ctx;
+    ( ( sx127x_t* ) modem_radio.ral.context )->hal_context = radio_ctx;
 #else
     // update modem_radio context with provided one
-    modem_radio->ral.context = radio_ctx;
+    modem_radio.ral.context = radio_ctx;
 #endif
     // Save modem radio context in case of direct access to radio by the modem
-    modem_set_radio_ctx( modem_radio->ral.context );
+    modem_set_radio_ctx( modem_radio.ral.context );
 }
 
 const void* smtc_modem_get_radio_context( void )
 {
     // Get radio context
-    return modem_radio->ral.context;
+    return modem_radio.ral.context;
 }
 
 bool smtc_modem_is_irq_flag_pending( void )


### PR DESCRIPTION
[Original SWL2001 did not have this initialization commented out](https://github.com/Lora-net/SWL2001/blob/a8ddc544043e72807cf7db532478e1dda734ae7c/lbm_lib/smtc_modem_core/smtc_modem.c#L192-L206):

```c
#if defined( SX128X )
ralf_t modem_radio = RALF_SX128X_INSTANTIATE( NULL );
#elif defined( SX126X )
ralf_t modem_radio = RALF_SX126X_INSTANTIATE( NULL );
#elif defined( LR11XX )
ralf_t modem_radio = RALF_LR11XX_INSTANTIATE( NULL );
#elif defined( LR20XX )
ralf_t modem_radio = RALF_LR20XX_INSTANTIATE( NULL );
#elif defined( SX127X )
#include "sx127x.h"
static sx127x_t sx127x;
ralf_t          modem_radio = RALF_SX127X_INSTANTIATE( &sx127x );
#else
#error "Please select radio board.."
#endif
``` 

High relationship with this issue in the zephyr https://github.com/Lora-net/usp_zephyr/issues/2